### PR TITLE
Enable PR Status Notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rise8-us/cato-repo-pr-approvers

--- a/.github/actions/post-to-slack/action.yml
+++ b/.github/actions/post-to-slack/action.yml
@@ -1,0 +1,75 @@
+name: Send Slack message
+description: Sends a Slack message
+
+inputs:
+  channel-id:
+    description: 'Slack channel ID'
+    required: true
+    type: string
+  message:
+    description: 'The message to send'
+    required: true
+    type: string
+  slack-bot-token:
+    description: 'The token of the Slack bot'
+    required: true
+  thread_ts:
+    description: 'The threaded timestamp on the message that was posted'
+    required: false
+    type: string
+outputs:
+  thread_ts:
+    description: 'The threaded timestamp on the message that was posted'
+    value: ${{ steps.send-message.outputs.thread_ts }}
+
+runs:
+  using: composite
+  steps:
+    - name: Send message
+      id: send-message
+      if: inputs.thread_ts == ''
+      uses: slackapi/slack-github-action@v1
+      with:
+        channel-id: ${{ inputs.channel-id }}
+        payload: |
+          {
+            "text": "Slack Message",
+            "unfurl_links": false,
+            "unfurl_media": false,
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ inputs.message }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
+
+    - name: Send message in existing thread
+      id: update-thread
+      if: inputs.thread_ts != ''
+      uses: slackapi/slack-github-action@v1
+      with:
+        channel-id: ${{ inputs.channel-id }}
+        payload: |
+          {
+            "text": "Slack Message",
+            "unfurl_links": false,
+            "unfurl_media": false,
+            "thread_ts": "${{ inputs.thread_ts }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ inputs.message }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}

--- a/.github/workflows/notify-pr-status.yml
+++ b/.github/workflows/notify-pr-status.yml
@@ -54,7 +54,7 @@ jobs:
           cat slack_message | awk '{printf "%s\\n", $0}' > slack_message.stripped
           BODY=$(cat slack_message.stripped)
           echo "payload=$BODY" >> $GITHUB_OUTPUT
-  
+
       - name: Post to Slack
         uses: rise8-us/cato-playbook/.github/actions/post-to-slack@main
         with:

--- a/.github/workflows/notify-pr-status.yml
+++ b/.github/workflows/notify-pr-status.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   notify-opened:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.event.pull_request.draft == false
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/notify-pr-status.yml
+++ b/.github/workflows/notify-pr-status.yml
@@ -1,0 +1,84 @@
+name: Notify PR Status
+
+on:
+  pull_request:
+    types: [opened, closed]
+    branches:
+      - main
+  pull_request_review:
+    types: [submitted]
+
+env:
+  ACTOR: ${{ github.actor }}
+  PR_NAME: ${{ github.event.pull_request.title }}
+  PR_BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+  PR_URL: ${{ github.event.pull_request.html_url }}
+  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+  PR_AUTHOR_URL: ${{ github.event.pull_request.user.html_url }}
+  PR_APPROVER: ${{ github.event.review.user.login }}
+  REPO: ${{ github.repository }}
+  REPO_URL: ${{ github.event.repository.html_url }}
+
+jobs:
+  notify-opened:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate message
+      id: generate-message
+      run: |
+        bash templates/slack-notify-pr-opened.tpl
+        cat slack_message | awk '{printf "%s\\n", $0}' > slack_message.stripped
+        BODY=$(cat slack_message.stripped)
+        echo "payload=$BODY" >> $GITHUB_OUTPUT
+
+    - name: Post to Slack
+      uses: rise8-us/cato-playbook/.github/actions/post-to-slack@main
+      with:
+        channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+        message: ${{ steps.generate-message.outputs.payload }}
+        slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  notify-approved:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate message
+        id: generate-message
+        run: |
+          bash templates/slack-notify-pr-approved.tpl
+          cat slack_message | awk '{printf "%s\\n", $0}' > slack_message.stripped
+          BODY=$(cat slack_message.stripped)
+          echo "payload=$BODY" >> $GITHUB_OUTPUT
+  
+      - name: Post to Slack
+        uses: rise8-us/cato-playbook/.github/actions/post-to-slack@main
+        with:
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          message: ${{ steps.generate-message.outputs.payload }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  notify-closed:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate message
+        id: generate-message
+        run: |
+          bash templates/slack-notify-pr-closed.tpl
+          cat slack_message | awk '{printf "%s\\n", $0}' > slack_message.stripped
+          BODY=$(cat slack_message.stripped)
+          echo "payload=$BODY" >> $GITHUB_OUTPUT
+
+      - name: Post to Slack
+        uses: rise8-us/cato-playbook/.github/actions/post-to-slack@main
+        with:
+          channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          message: ${{ steps.generate-message.outputs.payload }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,27 @@
+# Overriden rules for markdownlint
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# Default state for all rules
+default: true
+
+# MD007/ul-indent
+# Reasoning: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md007---unordered-list-indentation
+MD007:
+  indent: 4
+
+# MD013/line-length
+MD013:
+  line_length: 1500
+
+# MD024/no-duplicate-heading
+MD024:
+  siblings_only: true
+
+# MD028/no-blanks-blockquote
+MD028: false
+
+# MD029/ol-prefix
+MD029: false
+
+# MD033/no-inline-html
+MD033: false

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/punitlad/git-mob
+    rev: f111493
+    hooks:
+      - id: add-coauthors
+        stages: ["prepare-commit-msg"]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: detect-private-key
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ['--fix=auto']
+      - id: check-json
+      - id: pretty-format-json
+        name: format json
+        args: ['--autofix']
+        files: \.json(\.tpl)?$
+        types: [text]
+      - id: check-yaml
+        args: ["--allow-multiple-documents"]
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.39.0
+    hooks:
+      - id: markdownlint
+        args: [ "--fix" ]

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,13 @@
+# Description
+
+Please include a summary of the changes being made, and include relevant motivation and context.
+List any dependencies that are required for this change.
+
+## Type of change
+
+Please remove any options that are not relevant.
+
+- [ ] Documentation update 📚 (additions/changes to the playbook docs, spelling mistakes, grammar corrections)
+- [ ] Bug fix 🐛  (non-breaking change which fixes an issue)
+- [ ] New feature 🎉  (non-breaking change which adds functionality)
+- [ ] Breaking change 💔 (fix or feature that would cause existing functionality to not work as expected)

--- a/templates/slack-notify-pr-approved.tpl
+++ b/templates/slack-notify-pr-approved.tpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat << EOF > slack_message
+:github-check: A pull request has been *approved* by $ACTOR in the <$REPO_URL|$REPO> repository, and is *pending merge*.
+
+Merge it here: <$PR_URL|$PR_NAME>
+EOF

--- a/templates/slack-notify-pr-closed.tpl
+++ b/templates/slack-notify-pr-closed.tpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat << EOF > slack_message
+:github-merged: A pull request has been *merged* into main by $ACTOR in the <$REPO_URL|$REPO> repository :rocket:
+
+This closes the pull request <$PR_URL|$PR_NAME>, and the merged branch '$PR_BRANCH_NAME' has been automatically removed
+EOF

--- a/templates/slack-notify-pr-opened.tpl
+++ b/templates/slack-notify-pr-opened.tpl
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cat << EOF > slack_message
+:exclamation: A new pull request has been *opened* by $PR_AUTHOR in the <$REPO_URL|$REPO> repository, and is *pending approval*.
+
+Anyone in @cato-repo-pr-approvers can review it here: <$PR_URL|$PR_NAME>
+EOF


### PR DESCRIPTION
# Description

✅ Adds a basic PR template to fill out that describes what changes are being committed to the repo,

✅ Adds a new custom action `post-to-slack` that is used to streamline notification handling,

✅ Adds a new workflow, `notify-pr-status.yml`, that triggers whenever a PR is opened (_not drafted_), approved, or merged that then calls the `post-to-slack` action which sends the relevant notification through Slack to [#delivery-practice-cato](https://rise8inc.slack.com/archives/C02NXTWTRFT) that includes the PR name, PR author & a call to action to review the PR with a link to referenced PR,

✅ Adds new repo scoped variable (`SLACK_CHANNEL_ID`) and secret (`SLACK_BOT_TOKEN`) and configures automated Slack notifications that @mention a new Slack user group setup named `@cato-repo-pr-approvers` for notifying approvers of the relevant call-to-action,

✅ Adds a CODEOWNERS file to the repo and configures the repo's branch merge strategy to now enforce the requirement that a listed CODEOWNER in the new `cato-repo-pr-approvers` GitHub team approves all pull requests to the `main` branch to ensure proper validation before acceptance,

✅ Adds pre-commit configuration and markdown linting rules,

❌ Removes the smaller `secrel.png` image from the repo as well as a larger `SecRel.png` image & re-adds only one copy of the higher resolution image to the repo in order to correct OS case-insensitive file system issues detected when cloning the repo on MacOS,

❌ Removes old references to the smaller `secrel.png` image and ensures the higher resolution image is instead referenced.

## Slack notifications tests for review:

- A PR was **opened** in the repository:
<img width="650" alt="image" src="https://github.com/rise8-us/cato-playbook/assets/122806493/14b1c86d-eafd-4c05-97f7-8b3d8370d50c">

<br></br>

- A PR was **approved** in the repository:
<img width="621" alt="image" src="https://github.com/rise8-us/cato-playbook/assets/122806493/0751f37e-1243-4638-bd3c-b8eea43d5971">

<br></br>

- A PR was **merged** to the `main` branch of the repository:
<img width="680" alt="image" src="https://github.com/rise8-us/cato-playbook/assets/122806493/b34614b4-8669-45a7-aa33-01afc69e3157">

<br></br>

## Type of change(s)

- [x] New feature(s) 🎉  (non-breaking change(s) that add functionality)
- [x] Bug fix(s) 🐛  (non-breaking change(s) which fix an issue(s)